### PR TITLE
Documentation: fix edit_uri path

### DIFF
--- a/public/documentation/mkdocs.yml
+++ b/public/documentation/mkdocs.yml
@@ -17,6 +17,7 @@ copyright: Creative Commons CC BY NC ND
 # Repository
 repo_name: 'AtelierCartographie/Khartis'
 repo_url: 'https://github.com/AtelierCartographie/Khartis'
+edit_uri: edit/master/public/documentation/docs/
 
 # Theme and options
 theme:


### PR DESCRIPTION
This way, the edit button next to the page title leads to the correct URL.

Mkdocs ref: https://www.mkdocs.org/user-guide/configuration/#edit_uri

Warning: the project is using a really old Mkdocs version (even not compatible with Python3) and so the configuration is outdated. If Mkdocs (and the material theme) are upgraded, this change will require some further adaptations:

```yaml
theme:
  [...]
  features:
    - content.action.edit
```

If you want, I can help on this side but I would need to discuss to determine how the documentation site is built and deployed. There are several traces confusing me: a gh-pages branch, a .gitlab--ci.yaml and every HTML files tracked in master branch too.